### PR TITLE
make sure pcre-dev package is installed while building requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN set -ex \
                 libxml2-dev \
                 zlib-dev \
                 libffi-dev \
+                pcre-dev \
                 readline \
                 readline-dev \
                 ncurses \


### PR DESCRIPTION
make sure PCRE is available so we don't get the 'no internal routing support, rebuild with pcre support' message in uWSGI (and can use --route commands)