### PR TITLE
Switch to rapidpro/rapidpro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
     - $HOME/postgresql
 env:
   global:
+    - VERSION=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
     - IMAGE="rapidpro/rapidpro"
     - GREP_TIMEOUT=360
     - REGISTRY_USER=rapidproautomation
@@ -13,7 +14,6 @@ env:
     #       which is decrypted by Travis CI and set as environment variables
     - secure: "ftzg9S+hYbPRWVoXmhaZiOTqed4u63Lw90okq6w2AOs5T9LKuf1PVtvjGj7cfJCJqd/nANxedgxTvPeQXRc37rwLnJIikCA/D4e7XfQVOx66SbdyQxDwGtDxaWzR+cZw5yMc3pi4bl53/rXE3Gq0Hsetg7N/6YGBuxVPqIzidRHHo9zbSvb9gwB96bCPWOdtBDsZITHlxS0fNiWhuWi4m4qHlGtDUVaA47ZGfz3heXCnC79kjmJCLuSQvP+wNTOWeFSZ+Ajn0eE5RxqD4nfBRFkdhVJw52RfJqwvJdjnp4gTbHUtZ8fKQIbh+SXdBIXb7KSzhIVGsSl3ixzBvExgAnI6YxtLuzCfDi9D1uZQHWLne2Iexa2za7Y01OaQsLGedU0y5ioigXGayx9wirPCHMKTtzdWZ6G5E5i/DAAHciGW6BM0u/Vk9/Wf3ACxwdbe+pe7hsfPgCxb7KZ8mZmtH9Zx6qjWpqup69hMNaUYIIIY1hDJanO/rC4+6Zpznk/c3YF/AOwpkOsoT/uudnSWTauaDc6nw0PDMTHKdtPm6yjBN+T52Jb7YowlAjVneS+Ej9WHcSXoxjMeuK/RbFWCULX7ywGW0wqOLSD1qmR21A2ur6YRd9aSWVYCirDBHm2dEHEwl8by/Cs6P0oVXF+DA01VA1tBcT+xLCGbwFuNrMo="
   matrix:
-    - VERSION=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
     - VERSION="master"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_cache:
 
 before_script:
   - image="rapidpro/rapidpro"
-  - version=$(curl -s https://api.github.com/repos/nyaruka/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
+  - version=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
 
 script:
   # Setup postgresql and load sql dump if exists
@@ -39,7 +39,12 @@ script:
 
   # Build RapidPro and run it
   - docker pull rapidpro/rapidpro-base
-  - docker build --tag "$image" --build-arg RAPIDPRO_VERSION=$version .
+  - >
+    docker build --tag "$image" \
+      --build-arg RAPIDPRO_VERSION=$version \
+      --build-arg VCS_REF=$TRAVIS_COMMIT \
+      --build-arg BUILD_DATE=$(date -Iseconds) \
+      .
   - >
     docker run --name rapidpro \
       --env-file docker.envfile \

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,19 @@ cache:
     - $HOME/postgresql
 env:
   global:
+    - IMAGE="rapidpro/rapidpro"
     - GREP_TIMEOUT=360
     - REGISTRY_USER=rapidproautomation
     # NOTE: this is generated with `travis encrypt REGISTRY_PASS="the-password"`
     #       which is decrypted by Travis CI and set as environment variables
     - secure: "ftzg9S+hYbPRWVoXmhaZiOTqed4u63Lw90okq6w2AOs5T9LKuf1PVtvjGj7cfJCJqd/nANxedgxTvPeQXRc37rwLnJIikCA/D4e7XfQVOx66SbdyQxDwGtDxaWzR+cZw5yMc3pi4bl53/rXE3Gq0Hsetg7N/6YGBuxVPqIzidRHHo9zbSvb9gwB96bCPWOdtBDsZITHlxS0fNiWhuWi4m4qHlGtDUVaA47ZGfz3heXCnC79kjmJCLuSQvP+wNTOWeFSZ+Ajn0eE5RxqD4nfBRFkdhVJw52RfJqwvJdjnp4gTbHUtZ8fKQIbh+SXdBIXb7KSzhIVGsSl3ixzBvExgAnI6YxtLuzCfDi9D1uZQHWLne2Iexa2za7Y01OaQsLGedU0y5ioigXGayx9wirPCHMKTtzdWZ6G5E5i/DAAHciGW6BM0u/Vk9/Wf3ACxwdbe+pe7hsfPgCxb7KZ8mZmtH9Zx6qjWpqup69hMNaUYIIIY1hDJanO/rC4+6Zpznk/c3YF/AOwpkOsoT/uudnSWTauaDc6nw0PDMTHKdtPm6yjBN+T52Jb7YowlAjVneS+Ej9WHcSXoxjMeuK/RbFWCULX7ywGW0wqOLSD1qmR21A2ur6YRd9aSWVYCirDBHm2dEHEwl8by/Cs6P0oVXF+DA01VA1tBcT+xLCGbwFuNrMo="
+  matrix:
+    - VERSION=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
+    - VERSION="master"
 
+matrix:
+  allow_failures:
+    env: VERSION="master"
 # Update Docker Engine
 before_install:
   - sudo apt-get update
@@ -19,10 +26,6 @@ before_install:
 
 before_cache:
   - docker exec --user=postgres postgresql pg_dump rapidpro > $HOME/postgresql/rapidpro.sql
-
-before_script:
-  - image="rapidpro/rapidpro"
-  - version=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
 
 script:
   # Setup postgresql and load sql dump if exists
@@ -40,8 +43,8 @@ script:
   # Build RapidPro and run it
   - docker pull rapidpro/rapidpro-base
   - >
-    docker build --tag "$image" \
-      --build-arg RAPIDPRO_VERSION=$version \
+    docker build --tag "$IMAGE" \
+      --build-arg RAPIDPRO_VERSION=$VERSION \
       --build-arg VCS_REF=$TRAVIS_COMMIT \
       --build-arg BUILD_DATE=$(date -Iseconds) \
       .
@@ -52,7 +55,7 @@ script:
       --link postgresql \
       --publish 8000:8000 \
       --detach \
-      "$image"
+      "$IMAGE"
 
   - timeout $GREP_TIMEOUT grep -m 1 'static files copied' <(docker logs --follow rapidpro 2>&1)
   - timeout $GREP_TIMEOUT grep -m 1 'Compressing... done' <(docker logs --follow rapidpro 2>&1)
@@ -69,6 +72,6 @@ before_deploy:
 deploy:
   provider: script
   skip_cleanup: true
-  script: ./deploy.sh "$image" "$version"
+  script: ./deploy.sh "$IMAGE" "$VERSION"
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - $HOME/postgresql
 env:
   global:
-    - VERSION=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
     - IMAGE="rapidpro/rapidpro"
     - GREP_TIMEOUT=360
     - REGISTRY_USER=rapidproautomation
@@ -14,6 +13,7 @@ env:
     #       which is decrypted by Travis CI and set as environment variables
     - secure: "ftzg9S+hYbPRWVoXmhaZiOTqed4u63Lw90okq6w2AOs5T9LKuf1PVtvjGj7cfJCJqd/nANxedgxTvPeQXRc37rwLnJIikCA/D4e7XfQVOx66SbdyQxDwGtDxaWzR+cZw5yMc3pi4bl53/rXE3Gq0Hsetg7N/6YGBuxVPqIzidRHHo9zbSvb9gwB96bCPWOdtBDsZITHlxS0fNiWhuWi4m4qHlGtDUVaA47ZGfz3heXCnC79kjmJCLuSQvP+wNTOWeFSZ+Ajn0eE5RxqD4nfBRFkdhVJw52RfJqwvJdjnp4gTbHUtZ8fKQIbh+SXdBIXb7KSzhIVGsSl3ixzBvExgAnI6YxtLuzCfDi9D1uZQHWLne2Iexa2za7Y01OaQsLGedU0y5ioigXGayx9wirPCHMKTtzdWZ6G5E5i/DAAHciGW6BM0u/Vk9/Wf3ACxwdbe+pe7hsfPgCxb7KZ8mZmtH9Zx6qjWpqup69hMNaUYIIIY1hDJanO/rC4+6Zpznk/c3YF/AOwpkOsoT/uudnSWTauaDc6nw0PDMTHKdtPm6yjBN+T52Jb7YowlAjVneS+Ej9WHcSXoxjMeuK/RbFWCULX7ywGW0wqOLSD1qmR21A2ur6YRd9aSWVYCirDBHm2dEHEwl8by/Cs6P0oVXF+DA01VA1tBcT+xLCGbwFuNrMo="
   matrix:
+    - VERSION=""
     - VERSION="master"
 
 matrix:
@@ -26,6 +26,10 @@ before_install:
 
 before_cache:
   - docker exec --user=postgres postgresql pg_dump rapidpro > $HOME/postgresql/rapidpro.sql
+
+before_script:
+  - LATEST_TAG=$(curl -s https://api.github.com/repos/rapidpro/rapidpro/tags  | jq -r 'map(select(.name | test("^v[0-9\\.]+$"))) | .[0].name')
+  - VERSION=${VERSION:-$LATEST_TAG}
 
 script:
   # Setup postgresql and load sql dump if exists

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,22 @@
 # because it takes a long time to build)
 FROM rapidpro/rapidpro-base
 ARG RAPIDPRO_VERSION
+ARG VCS_REF
+ARG BUILD_DATE
 ENV PIP_RETRIES=120 \
     PIP_TIMEOUT=400 \
     PIP_DEFAULT_TIMEOUT=400 \
     C_FORCE_ROOT=1
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+        org.label-schema.name="RapidPro" \
+        org.label-schema.description="RapidPro allows organizations to visually build scalable interactive messaging applications." \
+        org.label-schema.url="https://www.rapidpro.io/" \
+        org.label-schema.vcs-ref=$VCS_REF \
+        org.label-schema.vcs-url="https://github.com/rapidpro/rapidpro" \
+        org.label-schema.vendor="Nyaruka, UNICEF" \
+        org.label-schema.version=$RAPIDPRO_VERSION \
+        org.label-schema.schema-version="1.0"
 
 # TODO determine if a more recent version of Node is needed
 # TODO extract openssl and tar to their own upgrade/install line
@@ -16,10 +28,10 @@ RUN set -ex \
 WORKDIR /rapidpro
 
 ENV RAPIDPRO_VERSION=${RAPIDPRO_VERSION:-master}
-RUN echo "Downloading RapidPro ${RAPIDPRO_VERSION} from https://github.com/nyaruka/rapidpro/archive/${RAPIDPRO_VERSION}.tar.gz" && \
-    wget "https://github.com/nyaruka/rapidpro/archive/${RAPIDPRO_VERSION}.tar.gz" && \
-    tar -xf ${RAPIDPRO_VERSION}.tar.gz --strip-components=1 && \
-    rm ${RAPIDPRO_VERSION}.tar.gz
+RUN echo "Downloading RapidPro ${RAPIDPRO_VERSION} from https://github.com/rapidpro/rapidpro/archive/${RAPIDPRO_VERSION}.tar.gz" && \
+    wget -O rapidpro.tar.gz "https://github.com/rapidpro/rapidpro/archive/${RAPIDPRO_VERSION}.tar.gz" && \
+    tar -xf rapidpro.tar.gz --strip-components=1 && \
+    rm rapidpro.tar.gz
 
 # workaround for broken dependency to old Pillow version from django-quickblocks
 RUN sed -i '/Pillow/c\Pillow==3.4.2' /rapidpro/pip-freeze.txt
@@ -57,6 +69,7 @@ RUN set -ex \
                 libzmq \
         && pip install -U virtualenv \
         && virtualenv /venv \
+        && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.1.1" \
         && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install -r /app/requirements.txt" \
         && runDeps="$( \
                 scanelf --needed --nobanner --recursive /venv \

--- a/settings.py
+++ b/settings.py
@@ -78,10 +78,4 @@ COMPRESS_URL = STATIC_URL
 # (e.g., translations) are stored
 COMPRESS_ROOT = STATIC_ROOT
 COMPRESS_CSS_HASHING_METHOD = 'content'
-COMPRESS_OFFLINE_CONTEXT = dict(
-    STATIC_URL=STATIC_URL,
-    base_template='frame.html',
-    debug=False,
-    testing=False,
-)
 COMPRESS_OFFLINE_MANIFEST = 'manifest-%s.json' % env('RAPIDPRO_VERSION', required=True)

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -4,7 +4,7 @@ if [ "x$MANAGEPY_COLLECTSTATIC" = "xon" ]; then
 	/venv/bin/python manage.py collectstatic --noinput --no-post-process
 fi
 if [ "x$MANAGEPY_COMPRESS" = "xon" ]; then
-	/venv/bin/python manage.py compress --extension=".haml" --force
+	/venv/bin/python manage.py compress --extension=".haml" --force -v0
 fi
 if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
 	set +x  # make sure the password isn't echoed to stdout


### PR DESCRIPTION
This PR:

- switches to tags now published on rapidpro/rapidpro
- adds a few standard docker container labels
- adds a temporary work around for pip & setuptools breaking builds, see https://github.com/pypa/setuptools/issues/942.

Was originally reported in #8.