### PR TITLE
Include sample docker compose for the rapidpro stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+#
+# NOTE: This docker-compose is not used for building the rapidpro docker
+#       releases, it is a compose file for local development purposes.
+#
+
+version: '2'
+services:
+  rapidpro:
+    image: rapidpro/rapidpro:master
+    depends_on:
+      - redis
+      - postgresql
+    ports:
+      - '8000:8000'
+    environment:
+      - DOMAIN_NAME=localhost
+      - ALLOWED_HOSTS=localhost
+      - TEMBA_HOST=localhost
+      - DJANGO_DEBUG=off
+      - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
+      - REDIS_URL=redis://redis:6379/0
+      - SECRET_KEY=super-secret-key
+      - MANAGEPY_COLLECTSTATIC=on
+      - MANAGEPY_COMPRESS=on
+      - MANAGEPY_INIT_DB=on
+      - MANAGEPY_MIGRATE=on
+  celery:
+    image: rapidpro/rapidpro
+    depends_on:
+      - rapidpro
+    links:
+      - redis
+      - postgresql
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
+      - REDIS_URL=redis://redis:6379/0
+      - SECRET_KEY=super-secret-key
+    command: ["/venv/bin/celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,msgs,flows,handler"]
+  redis:
+    image: redis:alpine
+  postgresql:
+    image: mdillon/postgis:9.6
+    environment:
+      - POSTGRES_DB=rapidpro
+  mage:
+    image: rapidpro/mage
+    depends_on:
+      - rapidpro
+    links:
+      - redis
+      - postgresql
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
+      - REDIS_URL=redis://redis/
+      - REDIS_DATABASE=8


### PR DESCRIPTION
I'm finding it quite useful to have a docker-compose file ready that brings up the full RapidPro stack (rapidpro, celery, redis, postgresql & mage).
This is the one I'm working with now.