### PR TITLE
include libmagic, dependency for python-magic included in rapidpro now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - timeout $GREP_TIMEOUT grep -m 1 'Compressing... done' <(docker logs --follow rapidpro 2>&1)
   - timeout $GREP_TIMEOUT grep -m 1 'Running migrations' <(docker logs --follow rapidpro 2>&1)
   - timeout $GREP_TIMEOUT grep -m 1 'spawned uWSGI http 1' <(docker logs --follow rapidpro 2>&1)
-  - docker exec rapidpro /venv/bin/python /rapidpro/manage.py check
+  - docker exec rapidpro python /rapidpro/manage.py check
 
 after_script:
   - docker logs rapidpro

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ RUN set -ex \
                 ncurses \
                 ncurses-dev \
                 libzmq \
-                libmagic \
         && pip install -U virtualenv \
         && virtualenv /venv \
         && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.1.1" \
@@ -80,7 +79,8 @@ RUN set -ex \
                         | sort -u \
         )" \
         && apk add --virtual .python-rundeps $runDeps \
-        && apk del .build-deps
+        && apk del .build-deps \
+        && apk add libmagic  # For some reason apk purges libmagic as it thinks it is not needed, installing separately here.
 
 # TODO should this be in startup.sh?
 RUN cd /rapidpro && bower install --allow-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,14 +79,14 @@ RUN set -ex \
                         | sort -u \
         )" \
         && apk add --virtual .python-rundeps $runDeps \
-        && apk del .build-deps \
-        && apk add libmagic  # For some reason apk purges libmagic as it thinks it is not needed, installing separately here.
+        && apk del .build-deps
 
 # TODO should this be in startup.sh?
 RUN cd /rapidpro && bower install --allow-root
 
 # Install `psql` command (needed for `manage.py dbshell` in stack/init_db.sql)
-RUN apk add --no-cache postgresql-client
+# Install `libmagic` (needed by rapidpro since v3.0.64)
+RUN apk add --no-cache postgresql-client libmagic
 
 RUN sed -i 's/sitestatic\///' /rapidpro/static/brands/rapidpro/less/style.less
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN set -ex \
                 ncurses \
                 ncurses-dev \
                 libzmq \
+                libmagic \
         && pip install -U virtualenv \
         && virtualenv /venv \
         && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.1.1" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,10 @@ RUN set -ex \
                 ncurses \
                 ncurses-dev \
                 libzmq \
-        && pip install -U virtualenv \
-        && virtualenv /venv \
-        && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install setuptools==33.1.1" \
-        && LIBRARY_PATH=/lib:/usr/lib /bin/sh -c "/venv/bin/pip install -r /app/requirements.txt" \
+        && pip install setuptools==33.1.1 \
+        && LIBRARY_PATH=/lib:/usr/lib pip install -r /app/requirements.txt \
         && runDeps="$( \
-                scanelf --needed --nobanner --recursive /venv \
+                scanelf --needed --nobanner --recursive /usr/local/ \
                         | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
                         | sort -u \
                         | xargs -r apk info --installed \
@@ -85,15 +83,15 @@ RUN set -ex \
 RUN cd /rapidpro && bower install --allow-root
 
 # Install `psql` command (needed for `manage.py dbshell` in stack/init_db.sql)
-# Install `libmagic` (needed by rapidpro since v3.0.64)
+# Install `libmagic` (needed since rapidpro v3.0.64)
 RUN apk add --no-cache postgresql-client libmagic
 
 RUN sed -i 's/sitestatic\///' /rapidpro/static/brands/rapidpro/less/style.less
 
-ENV UWSGI_VIRTUALENV=/venv UWSGI_WSGI_FILE=temba/wsgi.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=8 UWSGI_HARAKIRI=20
+ENV UWSGI_WSGI_FILE=temba/wsgi.py UWSGI_HTTP=:8000 UWSGI_MASTER=1 UWSGI_WORKERS=8 UWSGI_HARAKIRI=20
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)
 # These options don't appear to be configurable via environment variables, so pass them in here instead
-ENV STARTUP_CMD="/venv/bin/uwsgi --http-auto-chunked --http-keepalive"
+ENV STARTUP_CMD="/usr/local/bin/uwsgi --http-auto-chunked --http-keepalive"
 
 # ENV MANAGEPY_INIT_DB=on
 # ENV MANAGEPY_MIGRATE=on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - MANAGEPY_INIT_DB=on
       - MANAGEPY_MIGRATE=on
   celery:
-    image: rapidpro/rapidpro
+    image: rapidpro/rapidpro:master
     depends_on:
       - rapidpro
     links:
@@ -35,7 +35,7 @@ services:
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY=super-secret-key
-    command: ["/venv/bin/celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,msgs,flows,handler"]
+    command: ["celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,msgs,flows,handler"]
   redis:
     image: redis:alpine
   postgresql:
@@ -43,13 +43,13 @@ services:
     environment:
       - POSTGRES_DB=rapidpro
   mage:
-    image: rapidpro/mage
-    depends_on:
-      - rapidpro
-    links:
-      - redis
-      - postgresql
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
-      - REDIS_URL=redis://redis/
-      - REDIS_DATABASE=8
+   image: rapidpro/mage
+   depends_on:
+     - rapidpro
+   links:
+     - redis
+     - postgresql
+   environment:
+     - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
+     - REDIS_URL=redis://redis/
+     - REDIS_DATABASE=8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ django-cache-url==1.3.1
 uwsgi==2.0.14
 whitenoise==3.2.2
 
-# NOTE: only needed because the Alpine fixes aren't in the pypi release yet.
-https://github.com/ahupp/python-magic/archive/70c3b928a18ccc4171ce77547c2d889a5bbb8d97.zip
+# NOTE: needed for Alpine linux, pip-freeze.txt for rapidpro is behind
+python-magic==0.4.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ django-getenv==1.3.1
 django-cache-url==1.3.1
 uwsgi==2.0.14
 whitenoise==3.2.2
+
+# NOTE: only needed because the Alpine fixes aren't in the pypi release yet.
+https://github.com/ahupp/python-magic/archive/70c3b928a18ccc4171ce77547c2d889a5bbb8d97.zip

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 set -ex # fail on any error & print commands as they're run
 if [ "x$MANAGEPY_COLLECTSTATIC" = "xon" ]; then
-	/venv/bin/python manage.py collectstatic --noinput --no-post-process
+	python manage.py collectstatic --noinput --no-post-process
 fi
 if [ "x$MANAGEPY_COMPRESS" = "xon" ]; then
-	/venv/bin/python manage.py compress --extension=".haml" --force -v0
+	python manage.py compress --extension=".haml" --force -v0
 fi
 if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
 	set +x  # make sure the password isn't echoed to stdout
 	echo "*:*:*:*:$(echo \"$DATABASE_URL\" | cut -d'@' -f1 | cut -d':' -f3)" > $HOME/.pgpass
 	set -x
 	chmod 0600 $HOME/.pgpass
-	/venv/bin/python manage.py dbshell < init_db.sql
+	python manage.py dbshell < init_db.sql
 	rm $HOME/.pgpass
 fi
 if [ "x$MANAGEPY_MIGRATE" = "xon" ]; then
-	/venv/bin/python manage.py migrate
+	python manage.py migrate
 fi
 $STARTUP_CMD


### PR DESCRIPTION
In [v3.0.64](https://github.com/rapidpro/rapidpro/releases/tag/v3.0.64) `python-magic` was added as a dependency, this requires on libmagic being installed on the host.