### PR TITLE
Utils for clearing compressor cache on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ COPY settings.py /rapidpro/temba/
 # 500.html needed to keep the missing template from causing an exception during error handling
 COPY stack/500.html /rapidpro/templates/
 COPY stack/init_db.sql /rapidpro/
+COPY stack/clear-compressor-cache.py /rapidpro/
 
 EXPOSE 8000
 COPY stack/startup.sh /

--- a/README.md
+++ b/README.md
@@ -148,3 +148,8 @@ Environment variables
 
 *SECURE_PROXY_SSL_HEADER*
   Defaults to ``HTTP_X_FORWARDED_PROTO``
+
+*CLEAR_COMPRESSOR_CACHE*
+  Sometimes after a redeploy the compressor cache needs to be cleared
+  to make sure the static assets are rebuilt. Not set by default, set to ``on``
+  if you want to clear the cache every redeploy.

--- a/stack/clear-compressor-cache.py
+++ b/stack/clear-compressor-cache.py
@@ -1,0 +1,22 @@
+import redis
+from getenv import env
+from urlparse import urlparse
+from django.conf import settings
+from django.core.cache import cache
+
+settings.configure()
+
+key_prefix = cache.make_key('django_compressor')
+
+REDIS_URL = env('REDIS_URL', required=True)
+
+up = urlparse(REDIS_URL)
+redis_host = up.hostname
+redis_port = int(up.port or 6379)
+redis_db = int(up.path.lstrip('/'))
+
+redis = redis.Redis(host=redis_host, port=redis_port, db=redis_db)
+keys = redis.keys('%s.*' % (key_prefix,))
+for key in keys:
+    redis.delete(key)
+    print('Cleared Django Compressor key: %s' % (key,))

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -3,6 +3,9 @@ set -ex # fail on any error & print commands as they're run
 if [ "x$MANAGEPY_COLLECTSTATIC" = "xon" ]; then
 	python manage.py collectstatic --noinput --no-post-process
 fi
+if [ "x$CLEAR_COMPRESSOR_CACHE" = "xon" ]; then
+	/venv/bin/python clear-compressor-cache.py
+fi
 if [ "x$MANAGEPY_COMPRESS" = "xon" ]; then
 	python manage.py compress --extension=".haml" --force -v0
 fi
@@ -16,8 +19,5 @@ if [ "x$MANAGEPY_INIT_DB" = "xon" ]; then
 fi
 if [ "x$MANAGEPY_MIGRATE" = "xon" ]; then
 	python manage.py migrate
-fi
-if [ "x$CLEAR_COMPRESSOR_CACHE" = "xon" ]; then
-	/venv/bin/python clear-compressor-cache.py
 fi
 $STARTUP_CMD

--- a/stack/startup.sh
+++ b/stack/startup.sh
@@ -17,4 +17,7 @@ fi
 if [ "x$MANAGEPY_MIGRATE" = "xon" ]; then
 	python manage.py migrate
 fi
+if [ "x$CLEAR_COMPRESSOR_CACHE" = "xon" ]; then
+	/venv/bin/python clear-compressor-cache.py
+fi
 $STARTUP_CMD


### PR DESCRIPTION
For some reason this cache needs to be cleared after a new release. I'm not sure yet why, we're manually clearing it each deploy for now until we figure out the exact reason.