### PR TITLE
ensuring we activate the virtualenv for celery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY=super-secret-key
-    command: ["celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,msgs,flows,handler"]
+    command: ["/venv/bin/celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,msgs,flows,handler"]
   redis:
     image: redis:alpine
   postgresql:


### PR DESCRIPTION
Otherwise `docker-compose up` throws this error:
```ERROR: for celery  Cannot start service celery: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"celery\\\": executable file not found in $PATH\"\n"```