### PR TITLE
Updating minimal docker compose for a working rapidpro

### DIFF
--- a/courier.dockerfile
+++ b/courier.dockerfile
@@ -1,0 +1,37 @@
+FROM debian:stretch-slim
+
+RUN set -ex; \
+    addgroup --system courier; \
+    adduser --system --ingroup courier courier
+
+# Install ca-certificates so HTTPS works in general
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+ARG COURIER_REPO
+ENV COURIER_REPO=${COURIER_REPO:-nyaruka/courier}
+ARG COURIER_VERSION
+ENV COURIER_VERSION=${COURIER_VERSION:-1.2.84}
+
+RUN set -ex; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends wget; \
+  rm -rf /var/lib/apt/lists/*; \
+  \
+  wget -O courier.tar.gz "https://github.com/$COURIER_REPO/releases/download/v${COURIER_VERSION}/courier_${COURIER_VERSION}_linux_amd64.tar.gz"; \
+  mkdir /usr/local/src/courier; \
+  tar -xzC /usr/local/src/courier -f courier.tar.gz; \
+  \
+# Just grab the binary and ignore the other packaged files
+  mv /usr/local/src/courier/courier /usr/local/bin/; \
+  rm -rf /usr/local/src/courier courier.tar.gz; \
+  \
+  apt-get purge -y --auto-remove wget
+
+EXPOSE 8080
+
+USER courier
+
+ENTRYPOINT []
+CMD ["courier"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ALLOWED_HOSTS=192.168.29.192
       - TEMBA_HOST=192.168.29.192
       - DJANGO_DEBUG=off
-      - MAILROOM_URL=http://192.168.29.192:8090
+      - MAILROOM_URL=http://mailroom:8090
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY=super-secret-key
@@ -56,17 +56,17 @@ services:
     environment:
       - POSTGRES_DB=rapidpro
   courier:
-   image: praekeltfoundation/courier
-   depends_on:
-     - rapidpro
-   links:
-     - redis
-     - postgresql
-   environment:
-     - COURIER_DOMAIL=192.168.29.192
-     - COURIER_SPOOL_DIR=/tmp/courier/
-     - COURIER_DB=postgres://postgres:postgres@postgresql/rapidpro
-     - COURIER_REDIS=redis://redis:6379/8
+    image: praekeltfoundation/courier
+    depends_on:
+      - rapidpro
+    links:
+      - redis
+      - postgresql
+    environment:
+      - COURIER_DOMAIN=${RAPIDPRO_HOST:-locahost}
+      - COURIER_SPOOL_DIR=/tmp/courier/
+      - COURIER_DB=postgres://postgres:postgres@postgresql/rapidpro
+      - COURIER_REDIS=redis://redis:6379/8
   mailroom:
     container_name: mailroom
     build:
@@ -76,8 +76,8 @@ services:
       - redis
       - postgresql
     environment:
-      - MAILROOM_ADDRESS=192.168.29.192
-      - MAILROOM_DOMAIN=192.168.29.192
+      - MAILROOM_ADDRESS=0.0.0.0
+      - MAILROOM_DOMAIN=${RAPIDPRO_HOST:-localhost}
       - MAILROOM_REDIS=redis://redis:6379/15
       - MAILROOM_DB=postgres://postgres:postgres@postgresql/rapidpro?sslmode=disable
       - MAILROOM_LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     ports:
       - '8000:8000'
     environment:
-      - DOMAIN_NAME=192.168.29.192
-      - ALLOWED_HOSTS=192.168.29.192
-      - TEMBA_HOST=192.168.29.192
+      - DOMAIN_NAME=${RAPIDPRO_IP_ADDRESS}
+      - ALLOWED_HOSTS=${RAPIDPRO_IP_ADDRESS}
+      - TEMBA_HOST=${RAPIDPRO_IP_ADDRESS}
       - DJANGO_DEBUG=off
       - MAILROOM_URL=http://mailroom:8090
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
@@ -111,7 +111,7 @@ services:
       - redis
       - postgresql
     environment:
-      - COURIER_DOMAIN=192.168.29.192
+      - COURIER_DOMAIN=${RAPIDPRO_IP_ADDRESS}
       - COURIER_SPOOL_DIR=/tmp/courier/
       - COURIER_DB=postgres://postgres:postgres@postgresql/rapidpro
       - COURIER_REDIS=redis://redis:6379/8
@@ -127,7 +127,7 @@ services:
       - postgresql
     environment:
       - MAILROOM_ADDRESS=0.0.0.0
-      - MAILROOM_DOMAIN=192.168.29.192
+      - MAILROOM_DOMAIN=${RAPIDPRO_IP_ADDRESS}
       - MAILROOM_REDIS=redis://redis:6379/15
       - MAILROOM_DB=postgres://postgres:postgres@postgresql/rapidpro?sslmode=disable
       - MAILROOM_LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - redis
       - postgresql
     environment:
-      - COURIER_DOMAIN=${RAPIDPRO_HOST:-locahost}
+      - COURIER_DOMAIN=192.168.29.192
       - COURIER_SPOOL_DIR=/tmp/courier/
       - COURIER_DB=postgres://postgres:postgres@postgresql/rapidpro
       - COURIER_REDIS=redis://redis:6379/8
@@ -77,7 +77,7 @@ services:
       - postgresql
     environment:
       - MAILROOM_ADDRESS=0.0.0.0
-      - MAILROOM_DOMAIN=${RAPIDPRO_HOST:-localhost}
+      - MAILROOM_DOMAIN=192.168.29.192
       - MAILROOM_REDIS=redis://redis:6379/15
       - MAILROOM_DB=postgres://postgres:postgres@postgresql/rapidpro?sslmode=disable
       - MAILROOM_LOG_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,11 @@ services:
     ports:
       - '8000:8000'
     environment:
-      - DOMAIN_NAME=localhost
-      - ALLOWED_HOSTS=localhost
-      - TEMBA_HOST=localhost
+      - DOMAIN_NAME=192.168.29.192
+      - ALLOWED_HOSTS=192.168.29.192
+      - TEMBA_HOST=192.168.29.192
       - DJANGO_DEBUG=off
+      - MAILROOM_URL=http://192.168.29.192:8090
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY=super-secret-key
@@ -62,7 +63,22 @@ services:
      - redis
      - postgresql
    environment:
-     - COURIER_DOMAIN=localhost
+     - COURIER_DOMAIL=192.168.29.192
      - COURIER_SPOOL_DIR=/tmp/courier/
      - COURIER_DB=postgres://postgres:postgres@postgresql/rapidpro
      - COURIER_REDIS=redis://redis:6379/8
+  mailroom:
+    container_name: mailroom
+    build:
+      context: .
+      dockerfile: mailroom.dockerfile
+    links:
+      - redis
+      - postgresql
+    environment:
+      - MAILROOM_ADDRESS=192.168.29.192
+      - MAILROOM_DOMAIN=192.168.29.192
+      - MAILROOM_REDIS=redis://redis:6379/15
+      - MAILROOM_DB=postgres://postgres:postgres@postgresql/rapidpro?sslmode=disable
+      - MAILROOM_LOG_LEVEL=debug
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 version: '2'
 services:
   rapidpro:
-    image: sdehaan/rapidpro:v4
+    image: praekeltfoundation/rapidpro:v5.0.9
     depends_on:
       - redis
       - postgresql
@@ -26,24 +26,28 @@ services:
       - MANAGEPY_INIT_DB=on
       - MANAGEPY_MIGRATE=on
   celery_base:
-    image: sdehaan/rapidpro:v4
+    image: praekeltfoundation/rapidpro:v5.0.9
     depends_on:
       - rapidpro
     links:
       - redis
       - postgresql
+      - mailroom
+      - elasticsearch
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
       - SECRET_KEY=super-secret-key
     command: ["/venv/bin/celery", "--beat", "--app=temba", "worker", "--loglevel=INFO", "--queues=celery,flows"]
   celery_msgs:
-    image: sdehaan/rapidpro:v4
+    image: praekeltfoundation/rapidpro:v5.0.9
     depends_on:
       - rapidpro
     links:
       - redis
       - postgresql
+      - mailroom
+      - elasticsearch
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgresql/rapidpro
       - REDIS_URL=redis://redis:6379/0
@@ -55,8 +59,52 @@ services:
     image: mdillon/postgis:9.6
     environment:
       - POSTGRES_DB=rapidpro
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+    environment:
+      - bootstrap.memory_lock=true
+      - ES_HEAP_SIZE=128m
+      - ES_JAVA_OPTS=-Xms128m -Xmx128m
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+  rp-indexer:
+    container_name: rp-indexer
+    build:
+      context: .
+      dockerfile: rp-indexer.dockerfile
+      args:
+        - RP_INDEXER_VERSION=2.0.0
+    depends_on:
+     - rapidpro
+    links:
+      - postgresql
+      - elasticsearch
+    environment:
+      - INDEXER_DB=postgresql://postgres:postgres@postgresql/rapidpro?sslmode=disable
+      - INDEXER_ELASTIC_URL=http://elastic:changeme@elasticsearch:9200
+  rp-archiver:
+    container_name: rp-archiver
+    build:
+      context: .
+      dockerfile: rp-archiver.dockerfile
+      args:
+        - RP_ARCHIVER_VERSION=2.0.0
+    depends_on:
+      - rapidpro
+    links:
+      - postgresql
+    environment:
+      - ARCHIVER_DB=postgresql://postgres:postgres@postgresql/rapidpro?sslmode=disable
   courier:
-    image: praekeltfoundation/courier
+    container_name: courier
+    build:
+      context: .
+      dockerfile: courier.dockerfile
+      args:
+        - COURIER_VERSION=2.0.2
     depends_on:
       - rapidpro
     links:
@@ -72,6 +120,8 @@ services:
     build:
       context: .
       dockerfile: mailroom.dockerfile
+      args:
+        - MAILROOM_VERSION=2.0.9
     links:
       - redis
       - postgresql

--- a/mailroom.dockerfile
+++ b/mailroom.dockerfile
@@ -1,0 +1,38 @@
+FROM debian:stretch-slim
+
+RUN set -ex; \
+    addgroup --system mailroom; \
+    adduser --system --ingroup mailroom mailroom
+
+# Install ca-certificates so HTTPS works in general
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG MAILROOM_REPO
+ENV MAILROOM_REPO ${MAILROOM_REPO:-nyaruka/mailroom}
+ARG MAILROOM_VERSION
+ENV MAILROOM_VERSION ${MAILROOM_VERSION:-0.0.201}
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends wget; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    wget -O mailroom.tar.gz "https://github.com/$MAILROOM_REPO/releases/download/v${MAILROOM_VERSION}/mailroom_${MAILROOM_VERSION}_linux_amd64.tar.gz"; \
+    mkdir /usr/local/src/mailroom; \
+    tar -xzC /usr/local/src/mailroom -f mailroom.tar.gz; \
+    \
+    # Just grab the binary and ignore the other packaged files
+    mv /usr/local/src/mailroom/mailroom /usr/local/bin/; \
+    rm -rf /usr/local/src/mailroom mailroom.tar.gz; \
+    \
+    apt-get purge -y --auto-remove wget
+
+EXPOSE 8090
+
+USER mailroom
+
+ENTRYPOINT []
+CMD ["mailroom"]
+

--- a/rp-archiver.dockerfile
+++ b/rp-archiver.dockerfile
@@ -1,0 +1,34 @@
+FROM debian:stretch-slim
+
+# Install ca-certificates so HTTPS works in general
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system rp_archiver; \
+    adduser --system --ingroup rp_archiver rp_archiver
+
+ARG RP_ARCHIVER_REPO
+ENV RP_ARCHIVER_REPO=${RP_ARCHIVER_REPO:-nyaruka/rp-archiver}
+ARG RP_ARCHIVER_VERSION
+ENV RP_ARCHIVER_VERSION=${RP_ARCHIVER_VERSION:-1.0.23}
+
+RUN set -ex; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends wget; \
+  rm -rf /var/lib/apt/lists/*; \
+  \
+  wget -O rp-archiver.tar.gz "https://github.com/$RP_ARCHIVER_REPO/releases/download/v${RP_ARCHIVER_VERSION}/rp-archiver_${RP_ARCHIVER_VERSION}_linux_amd64.tar.gz"; \
+  mkdir /usr/local/src/rp-archiver; \
+  tar -xzC /usr/local/src/rp-archiver -f rp-archiver.tar.gz; \
+  \
+# Just grab the binary and ignore the other packaged files
+  mv /usr/local/src/rp-archiver/rp-archiver /usr/local/bin/; \
+  rm -rf /usr/local/src/rp-archiver rp-archiver.tar.gz; \
+  \
+  apt-get purge -y --auto-remove wget
+
+USER rp_archiver
+EXPOSE 8080
+CMD ["rp-archiver"]
+ENTRYPOINT []

--- a/rp-indexer.dockerfile
+++ b/rp-indexer.dockerfile
@@ -1,0 +1,35 @@
+FROM debian:stretch-slim
+
+RUN set -ex; \
+    addgroup --system rp_indexer; \
+    adduser --system --ingroup rp_indexer rp_indexer
+
+# Install ca-certificates so HTTPS works in general
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+ARG RP_INDEXER_REPO
+ENV RP_INDEXER_REPO=${RP_INDEXER_REPO:-nyaruka/rp-indexer}
+ARG RP_INDEXER_VERSION
+ENV RP_INDEXER_VERSION=${RP_INDEXER_VERSION:-1.0.23}
+
+RUN set -ex; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends wget; \
+  rm -rf /var/lib/apt/lists/*; \
+  \
+  wget -O rp-indexer.tar.gz "https://github.com/$RP_INDEXER_REPO/releases/download/v${RP_INDEXER_VERSION}/rp-indexer_${RP_INDEXER_VERSION}_linux_amd64.tar.gz"; \
+  mkdir /usr/local/src/rp-indexer; \
+  tar -xzC /usr/local/src/rp-indexer -f rp-indexer.tar.gz; \
+  \
+# Just grab the binary and ignore the other packaged files
+  mv /usr/local/src/rp-indexer/rp-indexer /usr/local/bin/; \
+  rm -rf /usr/local/src/rp-indexer rp-indexer.tar.gz; \
+  \
+  apt-get purge -y --auto-remove wget
+
+EXPOSE 8080
+USER rp_indexer
+ENTRYPOINT []
+CMD ["rp-indexer"]


### PR DESCRIPTION
* Added dockerfile for mailroom, rp-indexer, rp-archiver and courier
* Updated the docker-compose to use above dockerfile to build the dependency.
* Updated the dependency version based on the rapidpro main github page.
* Added elasticsearch service.

The dockerfile is based on the docker file in praekeltfoundation repo.